### PR TITLE
Remove use of \tl_to_lowercase:n

### DIFF
--- a/chemmacros.module.nomenclature.code.tex
+++ b/chemmacros.module.nomenclature.code.tex
@@ -341,25 +341,15 @@
 
 \seq_new:N   \l__chemmacros_iupac_shorthands_seq
 
-\group_begin:
-\char_set_catcode_active:N \~
-
-\cs_new_protected:Npn \chemmacros_define_iupac_shorthand:Npn #1
+\cs_new_protected:Npn \chemmacros_define_iupac_shorthand:Npn #1#2#
   {
     \seq_if_in:NnF \l__chemmacros_iupac_shorthands_seq {#1}
       { \seq_put_right:Nn \l__chemmacros_iupac_shorthands_seq {#1} }
-    \group_begin:
-    \__chemmacros_define_iupac_shorthand_aux_i:np {#1}
+    \__chemmacros_define_iupac_shorthand_aux:Nn #1
   }
 
-\cs_new_protected:Npn \__chemmacros_define_iupac_shorthand_aux_i:np #1#2#{
-    \char_set_lccode:nn {`~} {`#1}
-    \__chemmacros_define_iupac_shorthand_aux_ii:nn {#2}
-  }
-
-\cs_new_protected:Npn \__chemmacros_define_iupac_shorthand_aux_ii:nn #1#2
-  { \tl_to_lowercase:n { \group_end: \cs_set:Npn ~ } #1 {#2} }
-\group_end:
+\cs_new_protected:Npn \__chemmacros_define_iupac_shorthand_aux:Nn #1#2
+  { \char_set_active_eq:NN #1 #2 }
 
 \cs_new_protected:Npn \chemmacros_remove_shorthand:N #1
   {

--- a/chemmacros4.sty
+++ b/chemmacros4.sty
@@ -1283,16 +1283,9 @@
   
 \bool_new:N \l__chemmacros_inside_iupac_bool
 
-\group_begin:
-\char_set_catcode_active:N \~
-\char_set_lccode:nn {`~} {`|}
-\tl_to_lowercase:n { \group_end: \cs_set_eq:NN ~ } \chemmacros_break_point:
+\char_set_active_eq:NN | \chemmacros_break_point:
 
-\group_begin:
-\char_set_catcode_active:N \~
-\char_set_lccode:nn {`~} {`^}
-\tl_to_lowercase:n { \group_end: \cs_set_protected:Npn ~ }
-  { \chemmacros_superscript: }
+\char_set_active_eq:NN ^ \chemmacros_superscript:
 
 \group_begin:
 \char_set_catcode_active:N \|

--- a/chemmacros4.sty
+++ b/chemmacros4.sty
@@ -45,7 +45,6 @@
 \cs_generate_variant:Nn \tl_set_rescan:Nnn { NnV }
 \cs_generate_variant:Nn \tl_if_eq:nnTF     { V }
 \cs_generate_variant:Nn \tl_const:cn       { cV }
-\cs_generate_variant:Nn \tl_to_lowercase:n { f }
 
 % --------------------------------------------------------------------------
 % load required packages


### PR DESCRIPTION
As discussed by mail, the team are working on revising this area. The version of expl3 on CTAN will soon feature the 'new' `\char_set_active_eq:NN` (has been sent today), so this change should now be 'safe'.