### PR TITLE
Resolve issue with Pkg 'newfloat'

### DIFF
--- a/chemmacros.module.scheme.code.tex
+++ b/chemmacros.module.scheme.code.tex
@@ -102,7 +102,7 @@
     \DeclareFloatingEnvironment[{
       fileext = #2 ,
       listname = {\exp_not:N \chemmacros_translate:n {#1-list}} ,
-      name = #2
+      name = \chemmacros_translate:n {#1-name}
     }]{#1}
   }
 


### PR DESCRIPTION
When using Pkg 'newfloat', captions of 'scheme's have used 'los' as name. Changed the parameter read for setup of '\DeclareFloatingEnvironment{}'/'name'.