### PR TITLE
Fix cleverefs capitalise option

### DIFF
--- a/chemmacros.module.base.code.tex
+++ b/chemmacros.module.base.code.tex
@@ -272,7 +272,13 @@
       {
         \cs_if_exist:cF {cref@#1@name}
           {
-            \crefname {#1} {#2} {#3}
+            \chemmacros_tex_if:nnTF {@cref@capitalise} {}
+              {
+                \crefname {#1} {#4} {#5}
+              }
+              {
+                \crefname {#1} {#2} {#3}
+              }
             \Crefname {#1} {#4} {#5}
           }
       }

--- a/chemmacros.module.base.code.tex
+++ b/chemmacros.module.base.code.tex
@@ -273,12 +273,8 @@
         \cs_if_exist:cF {cref@#1@name}
           {
             \chemmacros_tex_if:nnTF {@cref@capitalise} {}
-              {
-                \crefname {#1} {#4} {#5}
-              }
-              {
-                \crefname {#1} {#2} {#3}
-              }
+              { \crefname {#1} {#4} {#5} }
+              { \crefname {#1} {#2} {#3} }
             \Crefname {#1} {#4} {#5}
           }
       }


### PR DESCRIPTION
Defining `\crefname` dependent on `@cref@capitalise` bool. (Acc. https://tex.stackexchange.com/a/126023/46653)