### PR TITLE
Translation fix

### DIFF
--- a/chemmacros.module.acid-base.code.tex
+++ b/chemmacros.module.acid-base.code.tex
@@ -67,7 +67,7 @@
       {l__chemmacros_#2_tl}
       { \chemmacros_translate:n {#2} }
     \chemmacros_if_compatibility:nnTF {>=} {5.7}
-      { \chemmacros_declare_translation:nnn {#2} {fallback} {#3} }
+      { \chemmacros_declare_translation:nnn {fallback} {#2} {#3} }
       { \DeclareTranslationFallback {#2} {#3} }
     \cs_set_protected:Npn #1
       {

--- a/chemmacros.module.lang.code.tex
+++ b/chemmacros.module.lang.code.tex
@@ -121,10 +121,10 @@
 \cs_new_protected:Npn \chemmacros_declare_translation:nnn #1#2#3
   {
     \declaretranslation
-      {#2}
-      { \c__chemmacros_keyword_prefix_tl #1 }
+      {#1}
+      { \c__chemmacros_keyword_prefix_tl #2 }
       {#3}
-    \prop_gput:Nnn \g_chemmacros_translations_prop {#1(#2)} {#3}
+    \prop_gput:Nnn \g_chemmacros_translations_prop {#2(#1)} {#3}
   }
 \cs_generate_variant:Nn \chemmacros_declare_translation:nnn {V}
 

--- a/chemmacros.module.phases.code.tex
+++ b/chemmacros.module.phases.code.tex
@@ -62,8 +62,8 @@
   {
     \tl_set:Nx \l__chemmacros_tmpa_tl { phase-\chemmacros_remove_backslash:N #1 }
     \chemmacros_declare_translation:Vnn
-      \l__chemmacros_tmpa_tl
       {fallback}
+      \l__chemmacros_tmpa_tl
       {#2}
     \__chemmacros_define_phase:Nx #1
       { \exp_not:N \chemmacros_translate:n { \exp_not:V \l__chemmacros_tmpa_tl } }


### PR DESCRIPTION
While the documentation specifies the macro as `\DeclareChemTranslation{<language>}{<key>}{<translation>}` the macro actually implemented the arguments as `\DeclareChemTranslation{<key>}{<language>}{<translation>}`. This pull request changes the implementation to be consistent with the documentation and `\DeclareTranslation`.
There will be compatibility issues which may need to be fixed as well.
I was unable to compile the documentation to check that everything was ok because of package version differences.