### PR TITLE
Added Norwegian (bokmål and nynorsk) translations

### DIFF
--- a/chemmacros.module.reactions.code.tex
+++ b/chemmacros.module.reactions.code.tex
@@ -349,60 +349,72 @@
 
 % --------------------------------------------------------------------------
 \ChemCompatibilityTo{5.6}
-\DeclareTranslationFallback   {list-of-reactions} {List~ of~ Reactions}
-\DeclareTranslation {English} {list-of-reactions} {List~ of~ Reactions}
-\DeclareTranslation {German}  {list-of-reactions} {Reaktionsverzeichnis}
-\DeclareTranslation {Italian} {list-of-reactions} {Elenco~ delle~ reazioni}
-\DeclareTranslation {French}  {list-of-reactions} {Table~ des~ r\'{e}actions}
-\DeclareTranslation {Dutch}   {list-of-reactions} {Lijst~ van~ reacties}
+\DeclareTranslationFallback     {list-of-reactions} {List~ of~ Reactions}
+\DeclareTranslation {English}   {list-of-reactions} {List~ of~ Reactions}
+\DeclareTranslation {German}    {list-of-reactions} {Reaktionsverzeichnis}
+\DeclareTranslation {Italian}   {list-of-reactions} {Elenco~ delle~ reazioni}
+\DeclareTranslation {French}    {list-of-reactions} {Table~ des~ r\'{e}actions}
+\DeclareTranslation {Dutch}     {list-of-reactions} {Lijst~ van~ reacties}
+\DeclareTranslation {Norwegian} {list-of-reactions} {Reaksjonsliste}
+\DeclareTranslation {Nynorsk}   {list-of-reactions} {Reaksjonsliste}
 
-\DeclareTranslationFallback   {reaction} {Reaction}
-\DeclareTranslation {English} {reaction} {Reaction}
-\DeclareTranslation {German}  {reaction} {Reaktion}
-\DeclareTranslation {Italian} {reaction} {Reazione}
-\DeclareTranslation {French}  {reaction} {R\'{e}action}
-\DeclareTranslation {Dutch}   {reaction} {Reactie}
+\DeclareTranslationFallback     {reaction} {Reaction}
+\DeclareTranslation {English}   {reaction} {Reaction}
+\DeclareTranslation {German}    {reaction} {Reaktion}
+\DeclareTranslation {Italian}   {reaction} {Reazione}
+\DeclareTranslation {French}    {reaction} {R\'{e}action}
+\DeclareTranslation {Dutch}     {reaction} {Reactie}
+\DeclareTranslation {Norwegian} {reaction} {Reaksjon}
+\DeclareTranslation {Nynorsk}   {reaction} {Reaksjon}
 \EndChemCompatibility
 
 \ChemCompatibilityFrom{5.6}
 \chemmacros_declare_translations:nn {list-of-reactions}
   {
-    fallback = List~ of~ Reactions ,
-    English  = List~ of~ Reactions ,
-    German   = Reaktionsverzeichnis ,
-    Italian  = Elenco~ delle~ reazioni ,
-    French   = Table~ des~ r\'{e}actions ,
-    Dutch    = Lijst~ van~ reacties
+    fallback  = List~ of~ Reactions ,
+    English   = List~ of~ Reactions ,
+    German    = Reaktionsverzeichnis ,
+    Italian   = Elenco~ delle~ reazioni ,
+    French    = Table~ des~ r\'{e}actions ,
+    Dutch     = Lijst~ van~ reacties ,
+    Norwegian = Reaksjonsliste ,
+    Nynorsk   = Reaksjonsliste
   }
 
 \chemmacros_declare_translations:nn {reaction}
   {
-    fallback = reaction ,
-    English  = reaction ,
-    German   = Reaktion ,
-    Italian  = reazione ,
-    French   = r\'{e}action ,
-    Dutch    = reactie
+    fallback  = reaction ,
+    English   = reaction ,
+    German    = Reaktion ,
+    Italian   = reazione ,
+    French    = r\'{e}action ,
+    Dutch     = reactie ,
+    Norwegian = reaksjon ,
+    Nynorsk   = reaksjon
   }
 
 \chemmacros_declare_translations:nn {reactions}
   {
-    fallback = reactions ,
-    English  = reactions ,
-    German   = Reaktionen ,
-    Italian  = reazioni ,
-    French   = r\'{e}actions ,
-    Dutch    = reacties
+    fallback  = reactions ,
+    English   = reactions ,
+    German    = Reaktionen ,
+    Italian   = reazioni ,
+    French    = r\'{e}actions ,
+    Dutch     = reacties ,
+    Norwegian = reaksjoner ,
+	Nynorsk   = reaksjonar
   }
 
 \chemmacros_declare_translations:nn {Reaction}
   {
-    fallback = Reaction ,
-    English  = Reaction ,
-    German   = Reaktion ,
-    Italian  = Reazione ,
-    French   = R\'{e}action ,
-    Dutch    = Reactie
+    fallback  = Reaction ,
+    English   = Reaction ,
+    German    = Reaktion ,
+    Italian   = Reazione ,
+    French    = R\'{e}action ,
+    Dutch     = Reactie ,
+    Norwegian = Reaksjon ,
+    Nynorsk   = Reaksjon
   }
 
 \chemmacros_declare_translations:nn {Reactions}
@@ -412,7 +424,9 @@
     German   = Reaktionen ,
     Italian  = Reazioni ,
     French   = R\'{e}actions ,
-    Dutch    = Reacties
+    Dutch    = Reacties ,
+    Norwegian = Reaksjoner ,
+    Nynorsk   = Reaksjonar
  }
 \EndChemCompatibility
 % --------------------------------------------------------------------------

--- a/chemmacros.module.scheme.code.tex
+++ b/chemmacros.module.scheme.code.tex
@@ -248,13 +248,17 @@
 
 % --------------------------------------------------------------------------
 \ChemCompatibilityTo{5.6}
-\DeclareTranslationFallback   {scheme-name} {Scheme}
-\DeclareTranslation {English} {scheme-name} {Scheme}
-\DeclareTranslation {German}  {scheme-name} {Schema}
+\DeclareTranslationFallback     {scheme-name} {Scheme}
+\DeclareTranslation {English}   {scheme-name} {Scheme}
+\DeclareTranslation {German}    {scheme-name} {Schema}
+\DeclareTranslation {Norwegian} {scheme-name} {Skjema}
+\DeclareTranslation {Nynorsk}   {scheme-name} {Skjema}
 
-\DeclareTranslationFallback   {scheme-list} {List~ of~ Schemes}
-\DeclareTranslation {English} {scheme-list} {List~ of~ Schemes}
-\DeclareTranslation {German}  {scheme-list} {Verzeichnis~ der~ Schemata}
+\DeclareTranslationFallback      {scheme-list} {List~ of~ Schemes}
+\DeclareTranslation {English}    {scheme-list} {List~ of~ Schemes}
+\DeclareTranslation {German}     {scheme-list} {Verzeichnis~ der~ Schemata}
+\DeclareTranslation {Norwegian}  {scheme-list} {Skjemaliste}
+\DeclareTranslation {Nynorsk}    {scheme-list} {Skjemaliste}
 \EndChemCompatibility
 
 \ChemCompatibilityFrom{5.6}
@@ -267,37 +271,47 @@
 
 \chemmacros_declare_translations:nn {scheme-list}
   {
-    fallback = List~ of~ Schemes ,
-    English  = List~ of~ Schemes ,
-    German   = Verzeichnis~ der~ Schemata
+    fallback    = List~ of~ Schemes ,
+    English     = List~ of~ Schemes ,
+    German      = Verzeichnis~ der~ Schemata,
+    Norwegian   = Skjemaliste,
+    Nynorsk     = Skjemaliste
   }
 
 \chemmacros_declare_translations:nn {scheme}
   {
-    fallback = scheme ,
-    English  = scheme ,
-    German   = Schema
+    fallback  = scheme ,
+    English   = scheme ,
+    German    = Schema ,
+    Norwegian = skjema ,
+    Nynorsk   = skjema
   }
 
 \chemmacros_declare_translations:nn {Scheme}
   {
-    fallback = Scheme ,
-    English  = Scheme ,
-    German   = Schema
+    fallback  = Scheme ,
+    English   = Scheme ,
+    German    = Schema ,
+    Norwegian = Skjema ,
+    Nynorsk   = Skjema
   }
 
 \chemmacros_declare_translations:nn {schemes}
   {
     fallback = schemes ,
     English  = schemes ,
-    German   = Schemata
+    German   = Schemata ,
+    Norwegian = skjema ,
+    Nynorsk   = skjema
   }
 
 \chemmacros_declare_translations:nn {Schemes}
   {
     fallback = Schemes ,
     English  = Schemes ,
-    German   = Schemata
+    German   = Schemata ,
+    Norwegian = Skjema ,
+	Nynorsk   = Skjema
   }
 \EndChemCompatibility
 


### PR DESCRIPTION
This pull request contains Norwegian translations. There are two written forms of Norwegian: Bokmål (norsk in babel) and nynorsk (nynorsk in babel), both of which are included.