### PR TITLE
Change key from K-acid to K-water

### DIFF
--- a/code/chemmacros.translations.code.tex
+++ b/code/chemmacros.translations.code.tex
@@ -8,7 +8,7 @@
     Dutch  = \mathrm {z}
   }
 
-\chemmacros_declare_translations:nn {K-acid}
+\chemmacros_declare_translations:nn {K-water}
   { Danish = \mathrm {v} }
 
 % --------------------------------------------------------------------------


### PR DESCRIPTION
The translation in this part of the code should be for the key K-water, not K-acid. The keyname has been changed to fit the translation.