### PR TITLE
Fix formatting of NMR position labels

### DIFF
--- a/code/chemmacros.spectroscopy.code.tex
+++ b/code/chemmacros.spectroscopy.code.tex
@@ -158,7 +158,7 @@
     pos-number / side .code:n =
       \tl_set:Nn \l__chemmacros_nmr_position_tl {-}
       \bool_set_true:N \l__chemmacros_nmr_position_side_bool ,
-    pos-number /  .initial:n  = side ,
+    pos-number    .initial:n  = side ,
     coupling-unit .tl_set:N   = \l__chemmacros_nmr_coupling_unit_tl ,
     coupling-pos  .choice: ,
     coupling-pos / sub .code:n =
@@ -364,7 +364,7 @@
         \bool_if:NF \l__chemmacros_nmr_position_side_bool
           {
             \exp_not:V \l__chemmacros_nmr_position_tl
-            \exp_not:n { _{#1} }
+            \exp_not:n { {#1} }
           }
       }
     \bool_if:NT \l__chemmacros_nmr_position_side_bool

--- a/code/chemmacros.sty
+++ b/code/chemmacros.sty
@@ -5186,7 +5186,7 @@
     pos-number / side .code:n =
       \tl_set:Nn \l__chemmacros_nmr_position_tl {-}
       \bool_set_true:N \l__chemmacros_nmr_position_side_bool ,
-    pos-number /  .initial:n  = side ,
+    pos-number    .initial:n  = side ,
     coupling-unit .tl_set:N   = \l__chemmacros_nmr_coupling_unit_tl ,
     coupling-pos  .choice: ,
     coupling-pos / sub .code:n =
@@ -5392,7 +5392,7 @@
         \bool_if:NF \l__chemmacros_nmr_position_side_bool
           {
             \exp_not:V \l__chemmacros_nmr_position_tl
-            \exp_not:n { _{#1} }
+            \exp_not:n { {#1} }
           }
       }
     \bool_if:NT \l__chemmacros_nmr_position_side_bool


### PR DESCRIPTION
e8e88c9 in its attempt to fix #24 introduced a bug, namely that it prefixed the argument in https://github.com/cgnieder/chemmacros/blob/05e767ac4a9d50a134a228f4aabdd952f6296765/code/chemmacros.spectroscopy.code.tex#L367 with an underscore to simulate `sub` mode of `pos-number`.

Indeed, the actual problem was, that OP of #34 wanted to use `sub` without specifying this in the `spectroscopy` module's option. The "default" value of `pos-number`, however, is `side`.

A bug in https://github.com/cgnieder/chemmacros/blob/05e767ac4a9d50a134a228f4aabdd952f6296765/code/chemmacros.spectroscopy.code.tex#L161 (superfluous `/`) caused the `spectroscopy` module to behave weirdly, producing a mix of `side` and `sub`. The supposed fix in e8e88c9 breaks the spectroscopy module when specifying both `sub` or `super` as it produces an underscore character (sub- or superscripted, respectively) followed by standard formatted text in these cases, while producing `sub` style when not specifying any `pos-number`.