### PR TITLE
Fix failing patch for book and report

### DIFF
--- a/code/chemmacros.sty
+++ b/code/chemmacros.sty
@@ -4918,9 +4918,17 @@
             \@starttoc {#2}
             \legacy_if:nT {@restonecol} { \twocolumn }
           }
-        \chemmacros_patch_cmd:Nnn \@chapter
-          { \addtocontents }
-          { \addtocontents {#2} { \protect \addvspace {10\p@} } \addtocontents }
+        \cs_if_exist:NTF \NR@chapter
+          {
+            \chemmacros_patch_cmd:Nnn \NR@chapter
+              { \addtocontents }
+              { \addtocontents {#2} { \protect \addvspace {10\p@} } \addtocontents }
+          }
+          {
+            \chemmacros_patch_cmd:Nnn \@chapter
+              { \addtocontents }
+              { \addtocontents {#2} { \protect \addvspace {10\p@} } \addtocontents }
+          }
       }
       {
         \cs_new_protected:cpn {listof#1s}
@@ -6712,7 +6720,7 @@
               {xltabular}
               {
                 \chemmacros_if_package_loaded:nTF {xltabular}
-                  {	  
+                  {
                     \bool_if:nTF {#1}
                       {
                         \begin {xltabular}
@@ -6738,7 +6746,7 @@
               {longtable}
               {
                 \chemmacros_if_package_loaded:nTF {longtable}
-                  {	  
+                  {
                     \bool_if:nTF {#1}
                       {
                         \begin {longtable}[l]
@@ -6760,7 +6768,7 @@
                   }
               }
             }
-	}
+        }
         { \msg_warning:nn {chemmacros} {missing-printreactants-style} }
     \group_end:
   }


### PR DESCRIPTION
Fixed failing patch for `book` and `report` classes with `hyperref` and removed some tabs.

Whenever the `book` or `report` class is used with `chemmacros` and `hyperref`, the following warning is displayed.
```
I failed to patch \@chapter . Please contact the(chemmacros) package author.
```
This is since `hyperref` changes the definition of `\@chapter` while the original definition remains in `\NR@chapter`. This update checks whether `\NR@chapter` is defined and applies the patch accordingly.